### PR TITLE
[🐸 Frogbot] Update version of com.fasterxml.jackson.core:jackson-databind to 2.12.7.1

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.7.1'
     implementation group: 'commons-collections', name: 'commons-collections', version: '3.2.1'
 }
 


### PR DESCRIPTION
<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)

</div>


## 📦 Vulnerable Dependencies
### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High | Undetermined | com.fasterxml.jackson.core:jackson-databind:2.10.1 | com.fasterxml.jackson.core:jackson-databind 2.10.1 | [2.12.7.1]<br>[2.13.4.1]<br>[2.14.0] | CVE-2022-42003 |

</div>

### 🔬 Research Details
**Description:**
[Jackson-databind]( https://github.com/FasterXML/jackson-databind) (previously known as "jackson-mapper-asl") is a streaming API library for Java. One of its components, `ObjectMapper` is responsible for serialization and deserialization of Java objects.
It was discovered that when the `UNWRAP_SINGLE_VALUE_ARRAYS` deserialization option is enabled (non-default), the deserialization of a deeply nested array could cause a stack exhaustion and subsequently crash the process.
This issue can be exploited when trying to deserialize untrusted data, for example -
```java
ObjectMapper mapper = new ObjectMapper();
mapper.enable(JsonParser.Feature.UNWRAP_SINGLE_VALUE_ARRAYS);
mapper.readTree(untrusted_data); 
```
The issue is likely to be exploited in vulnerable configurations since a public exploit exists.

**Remediation:**
##### Development mitigations

If possible, do not include the `UNWRAP_SINGLE_VALUE_ARRAYS` deserialization feature.
Specifically, remove this line from the code of the vulnerable application - 
`mapper.enable(JsonParser.Feature.UNWRAP_SINGLE_VALUE_ARRAYS);`


---
<div align='center'>

[🐸 JFrog Frogbot](https://github.com/jfrog/frogbot#readme)

</div>
